### PR TITLE
[Feature] .ai-context.md 初版作成（7セクション・TODOプレースホルダ）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,0 +1,78 @@
+# .ai-context.md
+
+AIエージェントが作業開始時に現在の状態・進行中Issue・次の手を把握するためのコンテキストファイル。
+**作業開始前に必ず読むこと。作業終了時に必ず更新すること。**
+
+---
+
+## 1. Status
+
+<!-- TODO: 現在の状態を works / broken で記載し、補足があれば追記する -->
+
+| 項目 | 状態 |
+|---|---|
+| 全体 | `TODO: works / broken` |
+| 補足 | `TODO: 状態の補足（例：CI緑、テスト未整備、etc.）` |
+
+---
+
+## 2. Active Issues
+
+<!-- TODO: 現在進行中の Issue をリンク付きで記載する。完了済みは除外し、常に最新状態を保つ -->
+
+| Issue | 要点 | 担当 |
+|---|---|---|
+| `TODO: #番号 リンク` | `TODO: 1行で要点` | `TODO: 担当エージェント or ユーザー` |
+
+---
+
+## 3. Decisions
+
+<!-- TODO: 仕様・方針の意思決定を記録する。「なぜそうしたか」を必ず残す -->
+
+| 日付 | 決定事項 | 理由 | 関連Issue |
+|---|---|---|---|
+| `TODO: YYYY-MM-DD` | `TODO: 何を決めたか` | `TODO: なぜそうしたか` | `TODO: #番号` |
+
+---
+
+## 4. Next actions
+
+<!-- TODO: 優先度順に次のアクションを記載する。エージェントはここを見て次の作業を判断する -->
+
+1. `TODO: 最優先のアクション（例：#番号 の AC を実装）`
+2. `TODO: 次のアクション`
+3. `TODO: その次のアクション`
+
+---
+
+## 5. Known pitfalls
+
+<!-- TODO: よくある罠・詰まりポイントを記載する。過去の失敗から学んだことをここに蓄積する -->
+
+- `TODO: 罠1（例：○○の設定を忘れると CI が落ちる）`
+- `TODO: 罠2`
+
+---
+
+## 6. Commands
+
+<!-- TODO: プロジェクトで使用するコマンドを記載する。os-template.yml の commands.* と対応させる -->
+
+| コマンド | 実行方法 | 備考 |
+|---|---|---|
+| format | `TODO: ./scripts/run format` | `TODO: 備考` |
+| lint | `TODO: ./scripts/run lint` | `TODO: 備考` |
+| typecheck | `TODO: ./scripts/run typecheck` | `TODO: 未使用の場合は理由を記載` |
+| test | `TODO: ./scripts/run test` | `TODO: 備考` |
+| build | `TODO: ./scripts/run build` | `TODO: 備考` |
+
+---
+
+## 7. CI Notes
+
+<!-- TODO: CI が落ちた時の典型原因と対処法を記載する。繰り返し発生するものを優先的に記録する -->
+
+| 典型原因 | 対処法 | 最終発生 |
+|---|---|---|
+| `TODO: 原因1（例：secrets スキャンで引っかかる）` | `TODO: 対処法` | `TODO: YYYY-MM-DD` |


### PR DESCRIPTION
## What / Why

Issue #5 で定義された `.ai-context.md` を作成。
`02_OS_Template_Spec.md` Section 6.3 の固定フォーマットに準拠し、Instance が埋めることを前提としたテンプレート。

Closes #5

## 変更内容

- 7セクション構成の `.ai-context.md` を新規作成
  - Status / Active Issues / Decisions / Next actions / Known pitfalls / Commands / CI Notes
- 各セクションに HTML コメントのガイダンス + TODO プレースホルダを配置
- Commands セクションに format / lint / typecheck / test / build の5項目を網羅

## How to test

- `.ai-context.md` を開き、7セクションが全て存在することを確認
- 各セクションに TODO プレースホルダがあることを確認
- Commands セクションに5項目があることを確認

## Risk / Rollback

- ドキュメントのみの変更のため、`git revert` で即時ロールバック可能
- 既存ファイルへの変更なし

## 今回やらないこと

- `scripts/init` による自動初期化（別 Issue）
- 具体的なプロジェクト固有内容の記載（Instance が埋める）