### PR TITLE
fix: guardrail の無限ハング問題を修正（タイムアウト追加）

### DIFF
--- a/.github/workflows/guardrail.yml
+++ b/.github/workflows/guardrail.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   guardrail:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/scripts/guardrail
+++ b/scripts/guardrail
@@ -7,11 +7,15 @@ import urllib.request
 import urllib.error
 import json
 
-def run_command(cmd, shell=False):
+def run_command(cmd, shell=False, timeout=30):
     if isinstance(cmd, str) and not shell:
         import shlex
         cmd = shlex.split(cmd)
-    result = subprocess.run(cmd, shell=shell, capture_output=True, text=True)
+    try:
+        result = subprocess.run(cmd, shell=shell, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        print(f"Command timed out after {timeout}s: {cmd}")
+        result = subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="timeout")
     return result
 
 def get_diff_text():
@@ -89,7 +93,7 @@ Diff:
     )
     
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=60) as response:
             result = json.loads(response.read().decode("utf-8"))
             text = result["candidates"][0]["content"]["parts"][0]["text"]
             
@@ -115,7 +119,7 @@ Diff:
                     return json.loads(fixed_text)
                 except json.JSONDecodeError:
                     raise e
-    except urllib.error.URLError as e:
+    except (urllib.error.URLError, TimeoutError) as e:
         print(f"Failed to call Gemini API: {e}")
         if hasattr(e, 'read'):
             print(e.read().decode('utf-8'))


### PR DESCRIPTION
## 概要

Gemini API コールにタイムアウトが設定されていないため、API の応答遅延・ハング時に guardrail ジョブが無限待ちになる不具合を修正。

## Root Cause

`urllib.request.urlopen(req)` にタイムアウト未設定。Python のデフォルトは `None`（無制限ブロック）。

## 修正内容

| 箇所 | 変更 |
|------|------|
| `scripts/guardrail` | `urlopen(req, timeout=60)` — API コール最大 60s |
| `scripts/guardrail` | `subprocess.run(..., timeout=30)` — gh コマンド等最大 30s |
| `scripts/guardrail` | `TimeoutError` を `URLError` と同じ catch 節で捕捉 |
| `.github/workflows/guardrail.yml` | `timeout-minutes: 5` — job レベルの最終防衛 |

## How to test

- このPRのCIで guardrail が5分以内に終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)